### PR TITLE
Make the itb flag a hiera lookup

### DIFF
--- a/manifests/cms_epel.pp
+++ b/manifests/cms_epel.pp
@@ -29,7 +29,7 @@
 class rpmrepos::cms_epel (
   $baseurl  = 'http://cms-install.fnal.gov/cobbler/repo_mirror',
   $enabled  = '1',
-  $itb      = false,
+  $itb      = hiera('repo_itb', 'false'),
   $priority = '90',
   $proxy    = 'absent'
 ) {

--- a/manifests/cms_osg.pp
+++ b/manifests/cms_osg.pp
@@ -29,7 +29,7 @@
 class rpmrepos::cms_osg (
   $baseurl   = 'http://cms-install.fnal.gov/cobbler/repo_mirror',
   $enabled   = '1',
-  $itb       = false,
+  $itb       = hiera('repo_itb', 'false'),
   $priority  = '80',
   $proxy     = 'absent',
 ) {


### PR DESCRIPTION
Without this, we have to individually set the parameter for each repository.  Additionally, we were not able to get the parameter set correctly.  Admittedly, we didn't try very hard.  This pull will bring the behavior of this module back into alignment with the old CMS module.
